### PR TITLE
Pop dependency graph

### DIFF
--- a/examples/partialorderplan.py
+++ b/examples/partialorderplan.py
@@ -1,0 +1,135 @@
+# Copyright 2022, 2023 LAAS-CNRS
+# Copyright 2023 DFKI GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Sebastian Stock, DFKI
+# - Selvakumar H S, LAAS-CNRS
+"""Example for parallel execution of a partial order plan."""
+import matplotlib.pyplot as plt
+import networkx as nx
+import unified_planning as up
+from parallel import (
+    Area,
+    Location,
+    Move,
+    Robot,
+    SendInfo,
+    Survey,
+    info_sent_fun,
+    is_surveyed_fun,
+    robot_at_fun,
+    visited_fun,
+)
+from unified_planning.plans import SequentialPlan
+from unified_planning.shortcuts import OneshotPlanner, PlanKind
+
+from up_bridge.bridge import Bridge
+from up_bridge.executor import Executor
+
+# Define the problem. The domain is re-used from examples/parallel.py
+
+
+def define_problem():
+    """Define the problem."""
+    bridge = Bridge()
+    bridge.create_types([Location, Area, Robot])
+
+    robot_at = bridge.create_fluent_from_function(robot_at_fun)
+    visited = bridge.create_fluent_from_function(visited_fun)
+    is_surveyed = bridge.create_fluent_from_function(is_surveyed_fun)
+    info_sent = bridge.create_fluent_from_function(info_sent_fun)
+
+    # Instead of the example in paralle.py, we use instantanious actions
+    move, [l_from, l_to] = bridge.create_action(
+        "Move", _callable=Move, l_from=Location, l_to=Location
+    )
+    move.add_precondition(info_sent(l_from))
+    move.add_precondition(info_sent(l_to))
+    move.add_precondition(robot_at(l_from))
+    move.add_effect(robot_at(l_from), False)
+    move.add_effect(robot_at(l_to), True)
+    move.add_effect(visited(l_to), True)
+
+    survey, [a] = bridge.create_action(  # pylint: disable=unused-variable
+        "Survey", _callable=Survey, area=Area
+    )
+    survey.add_effect(is_surveyed(), True)
+
+    send_info, [l] = bridge.create_action("SendInfo", _callable=SendInfo, location=Location)
+    # send_info.add_precondition(is_surveyed())
+    send_info.add_effect(info_sent(l), True)
+
+    l1 = bridge.create_object("l1", Location("l1"))
+    l2 = bridge.create_object("l2", Location("l2"))
+    l3 = bridge.create_object("l3", Location("l3"))
+    l4 = bridge.create_object("l4", Location("l4"))
+
+    problem = bridge.define_problem()
+    problem.set_initial_value(is_surveyed(), True)
+    problem.set_initial_value(robot_at(l1), True)
+    problem.set_initial_value(robot_at(l2), False)
+    problem.set_initial_value(robot_at(l3), False)
+    problem.set_initial_value(robot_at(l4), False)
+    problem.set_initial_value(visited(l1), True)
+    problem.set_initial_value(visited(l2), False)
+    problem.set_initial_value(visited(l3), False)
+    problem.set_initial_value(visited(l4), False)
+    problem.set_initial_value(info_sent(l1), False)
+    problem.set_initial_value(info_sent(l2), False)
+    problem.set_initial_value(info_sent(l3), False)
+    problem.set_initial_value(info_sent(l4), False)
+    problem.add_goal(visited(l2))
+    problem.add_goal(visited(l3))
+    problem.add_goal(visited(l4))
+    problem.add_goal(robot_at(l4))
+    return bridge, problem
+
+
+def main():
+    """Main function."""
+    up.shortcuts.get_env().credits_stream = None
+    bridge, problem = define_problem()
+
+    with OneshotPlanner(problem_kind=problem.kind) as planner:
+        print(problem.kind)
+        print(planner)
+        result = planner.solve(problem)
+        print("*** Result ***")
+        print(result.plan)
+        print("*** End of result ***")
+
+    plan = result.plan
+    if plan.kind == PlanKind.SEQUENTIAL_PLAN:
+        print("Converting SequentialPlan to PartialOrderPlan")
+        plan = plan.convert_to(PlanKind.PARTIAL_ORDER_PLAN, problem)
+        print(plan.get_adjacency_list)
+
+    dependency_graph = bridge.get_executable_graph(plan)
+    print(dependency_graph.adj)
+    executor = Executor()
+    executor.execute(dependency_graph)
+
+    # draw graph
+    plt.figure(figsize=(10, 10))
+
+    pos = nx.nx_pydot.pydot_layout(dependency_graph, prog="dot")
+    nx.draw(
+        dependency_graph, pos, with_labels=True, node_size=2000, node_color="skyblue", font_size=20
+    )
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -30,10 +30,12 @@ class TestPartialOrderPlanGeneration(unittest.TestCase):
         dep_graph = plan_to_dependency_graph(pop)
         self.assertTrue(dep_graph.has_node("start"))
         self.assertTrue(dep_graph.has_node("end"))
-        self.assertTrue(dep_graph.has_edge("start", plan.actions[0]))
-        self.assertTrue(dep_graph.has_edge("start", plan.actions[1]))
-        self.assertTrue(dep_graph.has_edge(plan.actions[0], "end"))
-        self.assertTrue(dep_graph.has_edge(plan.actions[1], "end"))
+        node0_name = f"{plan.actions[0].action.name}{plan.actions[0].actual_parameters}"
+        node1_name = f"{plan.actions[1].action.name}{plan.actions[1].actual_parameters}"
+        self.assertTrue(dep_graph.has_edge("start", node0_name))
+        self.assertTrue(dep_graph.has_edge("start", node1_name))
+        self.assertTrue(dep_graph.has_edge(node0_name, "end"))
+        self.assertTrue(dep_graph.has_edge(node1_name, "end"))
 
 
 if __name__ == "__main__":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Sebastian Stock, DFKI GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from unified_planning.plans.partial_order_plan import PartialOrderPlan
+from unified_planning.shortcuts import PlanKind
+from unified_planning.test.examples import get_example_problems
+
+from up_bridge.components.graph import _partial_order_plan_to_dependency_graph
+
+
+class TestPartialOrderPlanGeneration(unittest.TestCase):
+    def test_partial_order_plan_to_dependency_graph(self):
+        example_problems = get_example_problems()
+        problem, plan = example_problems["robot_fluent_of_user_type"]
+        pop = plan.convert_to(PlanKind.PARTIAL_ORDER_PLAN, problem)
+        assert isinstance(pop, PartialOrderPlan)
+        dep_graph = _partial_order_plan_to_dependency_graph(pop)
+        self.assertTrue(dep_graph.has_node("start"))
+        self.assertTrue(dep_graph.has_node("end"))
+        self.assertTrue(dep_graph.has_edge("start", plan.actions[0]))
+        self.assertTrue(dep_graph.has_edge("start", plan.actions[1]))
+        self.assertTrue(dep_graph.has_edge(plan.actions[0], "end"))
+        self.assertTrue(dep_graph.has_edge(plan.actions[1], "end"))
+
+
+if __name__ == "__main__":
+    test = TestPartialOrderPlanGeneration()
+    test.test_partial_order_plan_to_dependency_graph()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -18,7 +18,7 @@ from unified_planning.plans.partial_order_plan import PartialOrderPlan
 from unified_planning.shortcuts import PlanKind
 from unified_planning.test.examples import get_example_problems
 
-from up_bridge.components.graph import _partial_order_plan_to_dependency_graph
+from up_bridge.components.graph import plan_to_dependency_graph
 
 
 class TestPartialOrderPlanGeneration(unittest.TestCase):
@@ -27,7 +27,7 @@ class TestPartialOrderPlanGeneration(unittest.TestCase):
         problem, plan = example_problems["robot_fluent_of_user_type"]
         pop = plan.convert_to(PlanKind.PARTIAL_ORDER_PLAN, problem)
         assert isinstance(pop, PartialOrderPlan)
-        dep_graph = _partial_order_plan_to_dependency_graph(pop)
+        dep_graph = plan_to_dependency_graph(pop)
         self.assertTrue(dep_graph.has_node("start"))
         self.assertTrue(dep_graph.has_node("end"))
         self.assertTrue(dep_graph.has_edge("start", plan.actions[0]))

--- a/up_bridge/bridge.py
+++ b/up_bridge/bridge.py
@@ -37,7 +37,12 @@ from unified_planning.model import (
     Problem,
     Type,
 )
-from unified_planning.plans import ActionInstance, SequentialPlan, TimeTriggeredPlan
+from unified_planning.plans import (
+    ActionInstance,
+    PartialOrderPlan,
+    SequentialPlan,
+    TimeTriggeredPlan,
+)
 from unified_planning.shortcuts import BoolType, IntType, OneshotPlanner, RealType, UserType
 
 from up_bridge.components.graph import plan_to_dependency_graph
@@ -334,7 +339,9 @@ class Bridge:
         ).solve(problem)
         return result.plan.actions if result.plan else None
 
-    def get_executable_graph(self, plan: Union[SequentialPlan, TimeTriggeredPlan]) -> nx.DiGraph:
+    def get_executable_graph(
+        self, plan: Union[SequentialPlan, TimeTriggeredPlan, PartialOrderPlan]
+    ) -> nx.DiGraph:
         """Get executable graph from plan."""
         executable_graph = plan_to_dependency_graph(plan)
 

--- a/up_bridge/components/graph.py
+++ b/up_bridge/components/graph.py
@@ -31,6 +31,8 @@ def plan_to_dependency_graph(plan: Union[SequentialPlan, TimeTriggeredPlan]) -> 
         return _sequential_plan_to_dependency_graph(plan)
     if isinstance(plan, TimeTriggeredPlan):
         return _time_triggered_plan_to_dependency_graph(plan)
+    if isinstance(plan, PartialOrderPlan):
+        return _partial_order_plan_to_dependency_graph(plan)
     raise NotImplementedError("Plan type not supported")
 
 

--- a/up_bridge/components/graph.py
+++ b/up_bridge/components/graph.py
@@ -1,4 +1,5 @@
-# Copyright 2022 Selvakumar H S, LAAS-CNRS
+# Copyright 2022, 2023 LAAS-CNRS
+# Copyright 2023 DFKI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Authors:
+# - Selvakumar H S, LAAS-CNRS
+# - Sebastian Stock, DFKI
 
 """Module to convert UP Plan to Dependency Graph and execute it."""
 from typing import Union
 
 import networkx as nx
+from unified_planning.plans.partial_order_plan import PartialOrderPlan
 from unified_planning.plans.sequential_plan import SequentialPlan
 from unified_planning.plans.time_triggered_plan import TimeTriggeredPlan
 
@@ -27,6 +32,23 @@ def plan_to_dependency_graph(plan: Union[SequentialPlan, TimeTriggeredPlan]) -> 
     if isinstance(plan, TimeTriggeredPlan):
         return _time_triggered_plan_to_dependency_graph(plan)
     raise NotImplementedError("Plan type not supported")
+
+
+def _partial_order_plan_to_dependency_graph(plan: PartialOrderPlan) -> nx.DiGraph:
+    """Convert UP Partial Order Plan to Dependency Graph."""
+    adjancency_list = plan.get_adjacency_list
+    dependency_graph = nx.DiGraph(adjancency_list)
+    # add start node and edges to nodes without predecessors
+    start_nodes = [node for node, in_degree in dependency_graph.in_degree() if in_degree == 0]
+    dependency_graph.add_node("start", action="start", parameters=())
+    for node in start_nodes:
+        dependency_graph.add_edge("start", node)
+    # add end node and edges from nodes without successors
+    dependency_graph.add_node("end", action="end", parameters=())
+    for node, successors in adjancency_list.items():
+        if len(successors) == 0:
+            dependency_graph.add_edge(node, "end")
+    return dependency_graph
 
 
 def _sequential_plan_to_dependency_graph(plan: SequentialPlan) -> nx.DiGraph:


### PR DESCRIPTION
This PR enables to create a dependency graph from  a partial ordered plan.
Since the partial order plan is also a `DiGraph` we only have to re-use that via export through an adjacency list and add edges to start and end nodes.
Since UP allows to convert a `SequentialPlan` to a `PartialOrderPlan` by internally checking the actions' preconditions and effects this also allows to parallelise and execute sequential plans.